### PR TITLE
Add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,11 @@
+# Security process
+
+We take security issues seriously and welcome responsible disclosure from researchers discovering vulnerabilities in Foreman.  Please email [foreman-security@googlegroups.com](mailto:foreman-security@googlegroups.com) (a private address for the security team) with all reports. If you notice the security issue is related to a particular plugin, please mention the plugin within the body of the email to help us in routing the issue to the most authoritative source.
+
+We will endeavour to resolve high severity issues in the current stable release and lower severity issues in the next major release.  Announcements of security issues will be made on [the project's homepage](https://theforeman.org/security.html) and in the [Release Announcements category of our community forums](https://community.theforeman.org/c/release-announcements/8) when a release containing a fix is available to end users and credit will be given to the researcher if desired.
+
+The policy of the project is to treat all newly reported issues as private, and after evaluation, low to medium severity issues will be made public while high severity issues will be fixed under an embargo.  Typically the project supports only one major (x.y) release at a time, though high severity issues may also be fixed in the previous release if it was only recently superseded.
+
+## Security advisories
+
+All security advisories made for Foreman are listed on [the project's homepage](https://theforeman.org/security.html) with their corresponding [CVE identifier](https://cve.mitre.org/).


### PR DESCRIPTION
Add SECURITY.md based on the one on the project's homepage. Just adjusted where it pointed to itself, to point now to the homepage.

It talks about only supporting one release, should this be adjusted? Anything else to adjust here or in both files while on it?